### PR TITLE
Complete Algorithms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 go:
-    1.4
-    1.3
+    - 1.4
+    - 1.3
+    - 1.2
 before_install:
     - go get golang.org/x/tools/cmd/cover
     - go get github.com/mattn/goveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
-    tip
+    1.4
+    1.3
 before_install:
     - go get golang.org/x/tools/cmd/cover
     - go get github.com/mattn/goveralls

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ implementing a simple and concise encoder/decoder library for JWT.
 |     :+1:     | Sign      |     :+1:     |   HS256   |
 |     :+1:     | Verify    |     :+1:     |   HS384   |
 | :red_circle: | iss check |     :+1:     |   HS512   |
-| :red_circle: | sub check | :red_circle: |   RS256   |
-| :red_circle: | aud check | :red_circle: |   RS384   |
-| :red_circle: | exp check | :red_circle: |   RS512   |
+| :red_circle: | sub check |     :+1:     |   RS256   |
+| :red_circle: | aud check |     :+1:     |   RS384   |
+| :red_circle: | exp check |     :+1:     |   RS512   |
 | :red_circle: | nbf check | :red_circle: |   ES256   |
 | :red_circle: | iat check | :red_circle: |   ES384   |
 | :red_circle: | jti check | :red_circle: |   ES512   |
@@ -29,43 +29,52 @@ implementing a simple and concise encoder/decoder library for JWT.
 ### [Create token](http://godoc.com/github.com/benjic/jwt/#Encoder)
 
 ```go
-payload := &struct {
-    Payload
-    Admin  bool `json:"admin"`
-    UserID int  `json:"user_id"`
-}{
-    Payload: Payload{Issuer: "Ben Campbell"},
-    Admin:   true,
-    UserID:  1234,
-}
-tokenBuffer := bytes.NewBuffer(nil)
-err := NewEncoder(tokenBuffer, []byte("bogokey")).Encode(payload, HS256)
+	payload := &struct {
+		Payload
+		Admin  bool `json:"admin"`
+		UserID int  `json:"user_id"`
+	}{
+		Payload: Payload{Issuer: "Ben Campbell"},
+		Admin:   true,
+		UserID:  1234,
+	}
+	tokenBuffer := bytes.NewBuffer(nil)
 
-if err != nil {
-    panic(err)
-}
+	v := NewHSValidator(HS256)
+	v.Key = []byte("bogokey")
 
-fmt.Println(tokenBuffer.String())
+	err := NewEncoder(tokenBuffer, v).Encode(payload)
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(tokenBuffer.String())
+	// Output: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJCZW4gQ2FtcGJlbGwiLCJhZG1pbiI6dHJ1ZSwidXNlcl9pZCI6MTIzNH0.r4W8qDl8i8cUcRUxtA3hM0SZsLScHiBgBKZc_n_GrXI
+}
 ```
 
 ### [Consume a token](http://godoc.com/github.com/benjic/jwt/#Decoder)
 ```go
-token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJCZW4gQ2FtcGJlbGwiLCJhZG1pbiI6dHJ1ZSwidXNlcl9pZCI6MTIzNH0.r4W8qDl8i8cUcRUxtA3hM0SZsLScHiBgBKZc_n_GrXI="
+	token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJCZW4gQ2FtcGJlbGwiLCJhZG1pbiI6dHJ1ZSwidXNlcl9pZCI6MTIzNH0.r4W8qDl8i8cUcRUxtA3hM0SZsLScHiBgBKZc_n_GrXI"
 
-payload := &struct {
-    Payload
-    Admin  bool `json:"admin"`
-    UserID int  `json:"user_id"`
-}{}
+	payload := &struct {
+		Payload
+		Admin  bool `json:"admin"`
+		UserID int  `json:"user_id"`
+	}{}
 
-err := NewDecoder(bytes.NewBufferString(token), []byte("bogokey")).Decode(payload)
+	v := NewHSValidator(HS256)
+	v.Key = []byte("bogokey")
 
-if err != nil {
-    panic(err)
-}
+	err := NewDecoder(bytes.NewBufferString(token), v).Decode(payload)
 
-fmt.Printf("%+v\n", payload)
-// Output: &{Payload:{Issuer:Ben Campbell Subject: Audience: ExpirationTime:<nil> NotBefore:<nil> IssuedAt:<nil> JWTId: raw:[]} Admin:true UserID:1234}
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", payload)
+	// Output: &{Payload:{Issuer:Ben Campbell Subject: Audience: ExpirationTime:<nil> NotBefore:<nil> IssuedAt:<nil> JWTId: raw:[]} Admin:true UserID:1234}
 ```
 
 #### References

--- a/README.md
+++ b/README.md
@@ -29,52 +29,52 @@ implementing a simple and concise encoder/decoder library for JWT.
 ### [Create token](http://godoc.com/github.com/benjic/jwt/#Encoder)
 
 ```go
-	payload := &struct {
-		Payload
-		Admin  bool `json:"admin"`
-		UserID int  `json:"user_id"`
-	}{
-		Payload: Payload{Issuer: "Ben Campbell"},
-		Admin:   true,
-		UserID:  1234,
-	}
-	tokenBuffer := bytes.NewBuffer(nil)
+payload := &struct {
+	Payload
+	Admin  bool `json:"admin"`
+	UserID int  `json:"user_id"`
+}{
+	Payload: Payload{Issuer: "Ben Campbell"},
+	Admin:   true,
+	UserID:  1234,
+}
+tokenBuffer := bytes.NewBuffer(nil)
 
-	v := NewHSValidator(HS256)
-	v.Key = []byte("bogokey")
+v := NewHSValidator(HS256)
+v.Key = []byte("bogokey")
 
-	err := NewEncoder(tokenBuffer, v).Encode(payload)
+err := NewEncoder(tokenBuffer, v).Encode(payload)
 
-	if err != nil {
-		panic(err)
-	}
+if err != nil {
+	panic(err)
+}
 
-	fmt.Println(tokenBuffer.String())
-	// Output: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJCZW4gQ2FtcGJlbGwiLCJhZG1pbiI6dHJ1ZSwidXNlcl9pZCI6MTIzNH0.r4W8qDl8i8cUcRUxtA3hM0SZsLScHiBgBKZc_n_GrXI
+fmt.Println(tokenBuffer.String())
+// Output: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJCZW4gQ2FtcGJlbGwiLCJhZG1pbiI6dHJ1ZSwidXNlcl9pZCI6MTIzNH0.r4W8qDl8i8cUcRUxtA3hM0SZsLScHiBgBKZc_n_GrXI
 }
 ```
 
 ### [Consume a token](http://godoc.com/github.com/benjic/jwt/#Decoder)
 ```go
-	token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJCZW4gQ2FtcGJlbGwiLCJhZG1pbiI6dHJ1ZSwidXNlcl9pZCI6MTIzNH0.r4W8qDl8i8cUcRUxtA3hM0SZsLScHiBgBKZc_n_GrXI"
+token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJCZW4gQ2FtcGJlbGwiLCJhZG1pbiI6dHJ1ZSwidXNlcl9pZCI6MTIzNH0.r4W8qDl8i8cUcRUxtA3hM0SZsLScHiBgBKZc_n_GrXI"
 
-	payload := &struct {
-		Payload
-		Admin  bool `json:"admin"`
-		UserID int  `json:"user_id"`
-	}{}
+payload := &struct {
+	Payload
+	Admin  bool `json:"admin"`
+	UserID int  `json:"user_id"`
+}{}
 
-	v := NewHSValidator(HS256)
-	v.Key = []byte("bogokey")
+v := NewHSValidator(HS256)
+v.Key = []byte("bogokey")
 
-	err := NewDecoder(bytes.NewBufferString(token), v).Decode(payload)
+err := NewDecoder(bytes.NewBufferString(token), v).Decode(payload)
 
-	if err != nil {
-		panic(err)
-	}
+if err != nil {
+	panic(err)
+}
 
-	fmt.Printf("%+v\n", payload)
-	// Output: &{Payload:{Issuer:Ben Campbell Subject: Audience: ExpirationTime:<nil> NotBefore:<nil> IssuedAt:<nil> JWTId: raw:[]} Admin:true UserID:1234}
+fmt.Printf("%+v\n", payload)
+// Output: &{Payload:{Issuer:Ben Campbell Subject: Audience: ExpirationTime:<nil> NotBefore:<nil> IssuedAt:<nil> JWTId: raw:[]} Admin:true UserID:1234}
 ```
 
 #### References

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ implementing a simple and concise encoder/decoder library for JWT.
 | :red_circle: | sub check |     :+1:     |   RS256   |
 | :red_circle: | aud check |     :+1:     |   RS384   |
 | :red_circle: | exp check |     :+1:     |   RS512   |
-| :red_circle: | nbf check | :red_circle: |   ES256   |
-| :red_circle: | iat check | :red_circle: |   ES384   |
-| :red_circle: | jti check | :red_circle: |   ES512   |
+| :red_circle: | nbf check |     :+1:     |   ES256   |
+| :red_circle: | iat check |     :+1:     |   ES384   |
+| :red_circle: | jti check |     :+1:     |   ES512   |
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ implementing a simple and concise encoder/decoder library for JWT.
 |              |  Feature  |              | Algorithm |
 |--------------|-----------|--------------|-----------|
 |     :+1:     | Sign      |     :+1:     |   HS256   |
-|     :+1:     | Verify    | :red_circle: |   HS384   |
-| :red_circle: | iss check | :red_circle: |   HS512   |
+|     :+1:     | Verify    |     :+1:     |   HS384   |
+| :red_circle: | iss check |     :+1:     |   HS512   |
 | :red_circle: | sub check | :red_circle: |   RS256   |
 | :red_circle: | aud check | :red_circle: |   RS384   |
-| :red_circle: | exp check | :red_circle: |   HS512   |
+| :red_circle: | exp check | :red_circle: |   RS512   |
 | :red_circle: | nbf check | :red_circle: |   ES256   |
 | :red_circle: | iat check | :red_circle: |   ES384   |
 | :red_circle: | jti check | :red_circle: |   ES512   |

--- a/algorithms.go
+++ b/algorithms.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"strings"
 )
 
 const (
@@ -80,4 +81,7 @@ func (jwt *JWT) rawEncode() {
 
 	base64.URLEncoding.Encode(jwt.headerRaw, compactHeaderBuf.Bytes())
 	base64.URLEncoding.Encode(jwt.payloadRaw, compactPayloadBuf.Bytes())
+
+	jwt.headerRaw = []byte(strings.Trim(string(jwt.headerRaw), "="))
+	jwt.payloadRaw = []byte(strings.Trim(string(jwt.payloadRaw), "="))
 }

--- a/algorithms.go
+++ b/algorithms.go
@@ -22,20 +22,26 @@ import (
 )
 
 const (
+	// ES256 is the elliptic curve signing algorithm using 256 bits
+	ES256 = "ES256"
+	// ES384 is the elliptic curve signing algorithm using 384 bits
+	ES384 = "ES384"
+	// ES512 is the elliptic curve signing algorithm using 512 bits
+	ES512 = "ES512"
 	// HS256 is the HMAC SHA256 signing algorithm
 	HS256 = "HS256"
 	// HS384 is the HMAC SHA384 signing algorithm
 	HS384 = "HS384"
 	// HS512 is the HMAC SHA512 signing algorithm
 	HS512 = "HS512"
+	// None is the noop siging algorithm
+	None = "none"
 	// RS256 is a RSA algorithm using a SHA256 algorithm
 	RS256 = "RS256"
 	// RS384 is a RSA algorithm using a SHA384 algorithm
 	RS384 = "RS384"
 	// RS512 is a RSA algorithm using a SHA512 algorithm
 	RS512 = "RS512"
-	// None is the noop siging algorithm
-	None = "none"
 )
 
 type nonevalidator struct{}

--- a/algorithms.go
+++ b/algorithms.go
@@ -28,8 +28,12 @@ const (
 	HS384 = "HS384"
 	// HS512 is the HMAC SHA512 signing algorithm
 	HS512 = "HS512"
-	// RS256 is a RSA algorithm using  a SHA256 algorithm
+	// RS256 is a RSA algorithm using a SHA256 algorithm
 	RS256 = "RS256"
+	// RS384 is a RSA algorithm using a SHA384 algorithm
+	RS384 = "RS384"
+	// RS512 is a RSA algorithm using a SHA512 algorithm
+	RS512 = "RS512"
 	// None is the noop siging algorithm
 	None = "none"
 )

--- a/algorithms.go
+++ b/algorithms.go
@@ -14,11 +14,6 @@
 
 package jwt
 
-import (
-	"crypto/sha256"
-	"crypto/sha512"
-)
-
 const (
 	// HS256 is the HMAC SHA256 signing algorithm
 	HS256 = "HS256"
@@ -35,36 +30,21 @@ type nonevalidator struct{}
 // An Algorithm describes the signing algorithm as defined by the JWT specficiation
 type Algorithm string
 
-// A validator describes a pair of algorithmic operations that can be performed on
+// A Validator describes a pair of algorithmic operations that can be performed on
 // a give JWT.
-type validator interface {
+type Validator interface {
 	// validate asserts if a given token is signed correctly
-	validate(JWT *JWT, key []byte) (bool, error)
+	validate(JWT *JWT) (bool, error)
 	// Sign adds a new signature to a given JWT
-	sign(JWT *JWT, key []byte) error
+	sign(JWT *JWT) error
 }
 
-func getvalidator(alg Algorithm) (validator, error) {
-	switch alg {
-	case HS256:
-		return newHSValidator(sha256.New), nil
-	case HS384:
-		return newHSValidator(sha512.New384), nil
-	case HS512:
-		return newHSValidator(sha512.New), nil
-	case None:
-		return nonevalidator{}, nil
-	default:
-		return nil, ErrAlgorithmNotImplemented
-	}
-}
-
-func (v nonevalidator) validate(JWT *JWT, key []byte) (bool, error) {
+func (v nonevalidator) validate(JWT *JWT) (bool, error) {
 	// NOOP Validation :-1:
 	return true, nil
 }
 
-func (v nonevalidator) sign(JWT *JWT, key []byte) error {
+func (v nonevalidator) sign(JWT *JWT) error {
 
 	JWT.Header.Algorithm = None
 	JWT.Signature = []byte("")

--- a/algorithms.go
+++ b/algorithms.go
@@ -15,14 +15,8 @@
 package jwt
 
 import (
-	"bytes"
-	"crypto/hmac"
 	"crypto/sha256"
 	"crypto/sha512"
-	"encoding/base64"
-	"encoding/json"
-	"hash"
-	"strings"
 )
 
 const (
@@ -37,7 +31,6 @@ const (
 )
 
 type nonevalidator struct{}
-type hsValidator struct{ hashFunc func() hash.Hash }
 
 // An Algorithm describes the signing algorithm as defined by the JWT specficiation
 type Algorithm string
@@ -77,56 +70,5 @@ func (v nonevalidator) sign(JWT *JWT, key []byte) error {
 	JWT.Signature = []byte("")
 
 	// NOOP Signing :-1:
-	return nil
-}
-
-func newHSValidator(hashFunc func() hash.Hash) hsValidator {
-	return hsValidator{hashFunc: hashFunc}
-}
-
-func (v hsValidator) validate(JWT *JWT, key []byte) (bool, error) {
-	b64Signature := string(JWT.Signature)
-	if m := len(b64Signature) % 4; m != 0 {
-		b64Signature += strings.Repeat("=", 4-m)
-	}
-
-	signature, err := base64.URLEncoding.DecodeString(b64Signature)
-
-	if err != nil {
-		return false, ErrMalformedToken
-	}
-
-	magicString := string(JWT.headerRaw) + "." + string(JWT.payloadRaw)
-	mac := hmac.New(v.hashFunc, key)
-	mac.Write([]byte(magicString))
-
-	return hmac.Equal(signature, mac.Sum(nil)), nil
-}
-
-func (v hsValidator) sign(JWT *JWT, key []byte) error {
-
-	headerBuf := bytes.NewBuffer(nil)
-	payloadBuf := bytes.NewBuffer(nil)
-
-	// TODO: Determine if errors here are possible/relevant
-	json.NewEncoder(headerBuf).Encode(JWT.Header)
-	json.NewEncoder(payloadBuf).Encode(JWT.Payload)
-
-	compactHeaderBuf := bytes.NewBuffer(nil)
-	compactPayloadBuf := bytes.NewBuffer(nil)
-
-	json.Compact(compactHeaderBuf, headerBuf.Bytes())
-	json.Compact(compactPayloadBuf, payloadBuf.Bytes())
-
-	JWT.headerRaw = make([]byte, base64.URLEncoding.EncodedLen(len(compactHeaderBuf.Bytes())))
-	JWT.payloadRaw = make([]byte, base64.URLEncoding.EncodedLen(len(compactPayloadBuf.Bytes())))
-
-	base64.URLEncoding.Encode(JWT.headerRaw, compactHeaderBuf.Bytes())
-	base64.URLEncoding.Encode(JWT.payloadRaw, compactPayloadBuf.Bytes())
-
-	mac := hmac.New(v.hashFunc, key)
-	mac.Write([]byte(strings.Trim(string(JWT.headerRaw), "=") + "." + strings.Trim(string(JWT.payloadRaw), "=")))
-
-	JWT.Signature = []byte(base64.URLEncoding.EncodeToString(mac.Sum(nil)))
 	return nil
 }

--- a/algorithms_test.go
+++ b/algorithms_test.go
@@ -14,11 +14,7 @@
 
 package jwt
 
-import (
-	"bytes"
-	"crypto/sha256"
-	"testing"
-)
+import "testing"
 
 func TestNonevalidate(t *testing.T) {
 
@@ -68,72 +64,5 @@ func TestNonesign(t *testing.T) {
 
 	if len(JWT.Signature) != 0 {
 		t.Errorf("Invalid signature from nonevalidator. Got %#v; Expected %#v", JWT.Signature, []byte(""))
-	}
-}
-
-func TestHS256validate(t *testing.T) {
-
-	HS256V := newHSValidator(sha256.New)
-	b64Header := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
-	b64Payload := "eyJzdWIiOiIxMjM0NTY3ODkwIn0"
-	b64Signature := "Ayw1D-27S5W4XfiP-nFRm_BxSpN-v_cqlWUiwszjAB8"
-
-	JWT := &JWT{
-		Header: &Header{
-			Algorithm:   HS256,
-			ContentType: "JWT",
-		},
-		headerRaw: []byte(b64Header),
-		Payload: &Payload{
-			Subject: "1234567890",
-		},
-		payloadRaw: []byte(b64Payload),
-		Signature:  []byte(b64Signature),
-	}
-
-	valid, err := HS256V.validate(JWT, []byte("bogokey"))
-
-	if err != nil {
-		t.Errorf("Didn't expect nonevalidator to return an error: %s", err)
-	}
-
-	if !valid {
-		t.Errorf("Expected a valid signature")
-	}
-}
-
-func TestHS256sign(t *testing.T) {
-	HS256V := newHSValidator(sha256.New)
-	b64Signature := "Ayw1D-27S5W4XfiP-nFRm_BxSpN-v_cqlWUiwszjAB8="
-
-	JWT := &JWT{
-		Header: &Header{
-			Algorithm:   HS256,
-			ContentType: "JWT",
-		},
-		Payload: &Payload{
-			Subject: "1234567890",
-		},
-		Signature: []byte(""),
-	}
-
-	err := HS256V.sign(JWT, []byte("bogokey"))
-
-	if err != nil {
-		t.Errorf("Didn't expect hs256validator.Sign to return an error: %s", err)
-	}
-
-	if !bytes.Equal(JWT.Signature, []byte(b64Signature)) {
-		t.Errorf("Invalid signature from hs256validator. Got %#v; Expected %#v", string(JWT.Signature), b64Signature)
-	}
-
-	err = HS256V.sign(JWT, []byte("definitely the wrong key"))
-
-	if err != nil {
-		t.Errorf("Didn't expect hs256validator.Sign to return an error: %s", err)
-	}
-
-	if bytes.Equal(JWT.Signature, []byte(b64Signature)) {
-		t.Errorf("An invalid key for hs256validator returned an unexpected value: %#v.", JWT.Signature)
 	}
 }

--- a/algorithms_test.go
+++ b/algorithms_test.go
@@ -31,7 +31,7 @@ func TestNonevalidate(t *testing.T) {
 		Signature: []byte(nil),
 	}
 
-	valid, err := nv.validate(JWT, []byte("bogokey"))
+	valid, err := nv.validate(JWT)
 
 	if err != nil {
 		t.Errorf("Didn't expect nonevalidator to return an error: %s", err)
@@ -56,7 +56,7 @@ func TestNonesign(t *testing.T) {
 		Signature: []byte(nil),
 	}
 
-	err := nv.sign(JWT, []byte("bogokey"))
+	err := nv.sign(JWT)
 
 	if err != nil {
 		t.Errorf("Didn't expect nonevalidator.Sign to return an error: %s", err)

--- a/algorithms_test.go
+++ b/algorithms_test.go
@@ -16,6 +16,7 @@ package jwt
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"testing"
 )
 
@@ -72,7 +73,7 @@ func TestNonesign(t *testing.T) {
 
 func TestHS256validate(t *testing.T) {
 
-	HS256V := hs256validator{}
+	HS256V := newHSValidator(sha256.New)
 	b64Header := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
 	b64Payload := "eyJzdWIiOiIxMjM0NTY3ODkwIn0"
 	b64Signature := "Ayw1D-27S5W4XfiP-nFRm_BxSpN-v_cqlWUiwszjAB8"
@@ -102,7 +103,7 @@ func TestHS256validate(t *testing.T) {
 }
 
 func TestHS256sign(t *testing.T) {
-	HS256V := hs256validator{}
+	HS256V := newHSValidator(sha256.New)
 	b64Signature := "Ayw1D-27S5W4XfiP-nFRm_BxSpN-v_cqlWUiwszjAB8="
 
 	JWT := &JWT{

--- a/es.go
+++ b/es.go
@@ -1,0 +1,33 @@
+// Copyright 2015 Benjamin Campbell <benji@benjica.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jwt
+
+// An ESValidator implments the validator interface and provides a signing and Validation
+// tool for Elliptic curve signed tokens
+type ESValidator struct{}
+
+// NewESValidator instantiates a new instance of a parameterized Elliptic validator
+func NewESValidator(algorithm Algorithm) (v ESValidator, err error) {
+	switch algorithm {
+	case ES256:
+		return v, err
+	default:
+		return v, ErrAlgorithmNotImplemented
+	}
+}
+
+func (v ESValidator) sign(jwt *JWT) error { return nil }
+
+func (v ESValidator) validate(jwt *JWT) (bool, error) { return false, nil }

--- a/es_test.go
+++ b/es_test.go
@@ -1,0 +1,66 @@
+// Copyright 2015 Benjamin Campbell <benji@benjica.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jwt
+
+import "testing"
+
+func TestESSign(t *testing.T) {
+	v, _ := NewESValidator(ES256)
+
+	jwt := &JWT{
+		Header: &Header{
+			ContentType: "JWT",
+		},
+		Payload: &Payload{
+			Subject: "1234567890",
+		},
+	}
+
+	//NOOP test
+	v.sign(jwt)
+}
+func TestNewESValidator(t *testing.T) {
+	cases := []struct {
+		Algorithm     Algorithm
+		ExpectedError error
+		Reason        string
+	}{
+		{None, ErrAlgorithmNotImplemented, "did not expect to get a valid RS validator"},
+	}
+
+	for _, c := range cases {
+		_, err := NewESValidator(c.Algorithm)
+
+		if err != c.ExpectedError {
+			t.Errorf("%s: got %s", c.Reason, err)
+		}
+	}
+}
+
+func TestESValidate(t *testing.T) {
+	v, _ := NewESValidator(ES256)
+
+	jwt := &JWT{
+		Header: &Header{
+			ContentType: "JWT",
+		},
+		Payload: &Payload{
+			Subject: "1234567890",
+		},
+	}
+
+	//NOOP test
+	v.validate(jwt)
+}

--- a/hs.go
+++ b/hs.go
@@ -15,12 +15,10 @@
 package jwt
 
 import (
-	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/base64"
-	"encoding/json"
 	"hash"
 	"strings"
 )
@@ -71,25 +69,7 @@ func (v hsValidator) validate(JWT *JWT) (bool, error) {
 func (v hsValidator) sign(JWT *JWT) error {
 
 	JWT.Header.Algorithm = v.algorithm
-
-	headerBuf := bytes.NewBuffer(nil)
-	payloadBuf := bytes.NewBuffer(nil)
-
-	// TODO: Determine if errors here are possible/relevant
-	json.NewEncoder(headerBuf).Encode(JWT.Header)
-	json.NewEncoder(payloadBuf).Encode(JWT.Payload)
-
-	compactHeaderBuf := bytes.NewBuffer(nil)
-	compactPayloadBuf := bytes.NewBuffer(nil)
-
-	json.Compact(compactHeaderBuf, headerBuf.Bytes())
-	json.Compact(compactPayloadBuf, payloadBuf.Bytes())
-
-	JWT.headerRaw = make([]byte, base64.URLEncoding.EncodedLen(len(compactHeaderBuf.Bytes())))
-	JWT.payloadRaw = make([]byte, base64.URLEncoding.EncodedLen(len(compactPayloadBuf.Bytes())))
-
-	base64.URLEncoding.Encode(JWT.headerRaw, compactHeaderBuf.Bytes())
-	base64.URLEncoding.Encode(JWT.payloadRaw, compactPayloadBuf.Bytes())
+	JWT.rawEncode()
 
 	mac := hmac.New(v.hashFunc, v.Key)
 	mac.Write([]byte(strings.Trim(string(JWT.headerRaw), "=") + "." + strings.Trim(string(JWT.payloadRaw), "=")))

--- a/hs.go
+++ b/hs.go
@@ -1,0 +1,77 @@
+// Copyright 2015 Benjamin Campbell <benji@benjica.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jwt
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"encoding/base64"
+	"encoding/json"
+	"hash"
+	"strings"
+)
+
+type hsValidator struct{ hashFunc func() hash.Hash }
+
+func newHSValidator(hashFunc func() hash.Hash) hsValidator {
+	return hsValidator{hashFunc: hashFunc}
+}
+
+func (v hsValidator) validate(JWT *JWT, key []byte) (bool, error) {
+	b64Signature := string(JWT.Signature)
+	if m := len(b64Signature) % 4; m != 0 {
+		b64Signature += strings.Repeat("=", 4-m)
+	}
+
+	signature, err := base64.URLEncoding.DecodeString(b64Signature)
+
+	if err != nil {
+		return false, ErrMalformedToken
+	}
+
+	magicString := string(JWT.headerRaw) + "." + string(JWT.payloadRaw)
+	mac := hmac.New(v.hashFunc, key)
+	mac.Write([]byte(magicString))
+
+	return hmac.Equal(signature, mac.Sum(nil)), nil
+}
+
+func (v hsValidator) sign(JWT *JWT, key []byte) error {
+
+	headerBuf := bytes.NewBuffer(nil)
+	payloadBuf := bytes.NewBuffer(nil)
+
+	// TODO: Determine if errors here are possible/relevant
+	json.NewEncoder(headerBuf).Encode(JWT.Header)
+	json.NewEncoder(payloadBuf).Encode(JWT.Payload)
+
+	compactHeaderBuf := bytes.NewBuffer(nil)
+	compactPayloadBuf := bytes.NewBuffer(nil)
+
+	json.Compact(compactHeaderBuf, headerBuf.Bytes())
+	json.Compact(compactPayloadBuf, payloadBuf.Bytes())
+
+	JWT.headerRaw = make([]byte, base64.URLEncoding.EncodedLen(len(compactHeaderBuf.Bytes())))
+	JWT.payloadRaw = make([]byte, base64.URLEncoding.EncodedLen(len(compactPayloadBuf.Bytes())))
+
+	base64.URLEncoding.Encode(JWT.headerRaw, compactHeaderBuf.Bytes())
+	base64.URLEncoding.Encode(JWT.payloadRaw, compactPayloadBuf.Bytes())
+
+	mac := hmac.New(v.hashFunc, key)
+	mac.Write([]byte(strings.Trim(string(JWT.headerRaw), "=") + "." + strings.Trim(string(JWT.payloadRaw), "=")))
+
+	JWT.Signature = []byte(base64.URLEncoding.EncodeToString(mac.Sum(nil)))
+	return nil
+}

--- a/hs_test.go
+++ b/hs_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 )
 
-func TestHS256validate(t *testing.T) {
+func TestHSvalidate(t *testing.T) {
 
 	HS256V := NewHSValidator(HS256)
 	HS256V.Key = []byte("bogokey")
@@ -52,7 +52,7 @@ func TestHS256validate(t *testing.T) {
 	}
 }
 
-func TestHS256sign(t *testing.T) {
+func TestHSsign(t *testing.T) {
 	HS256V := NewHSValidator(HS256)
 	HS256V.Key = []byte("bogokey")
 

--- a/hs_test.go
+++ b/hs_test.go
@@ -16,13 +16,14 @@ package jwt
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"testing"
 )
 
 func TestHS256validate(t *testing.T) {
 
-	HS256V := newHSValidator(sha256.New)
+	HS256V := NewHSValidator(HS256)
+	HS256V.Key = []byte("bogokey")
+
 	b64Header := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
 	b64Payload := "eyJzdWIiOiIxMjM0NTY3ODkwIn0"
 	b64Signature := "Ayw1D-27S5W4XfiP-nFRm_BxSpN-v_cqlWUiwszjAB8"
@@ -40,7 +41,7 @@ func TestHS256validate(t *testing.T) {
 		Signature:  []byte(b64Signature),
 	}
 
-	valid, err := HS256V.validate(JWT, []byte("bogokey"))
+	valid, err := HS256V.validate(JWT)
 
 	if err != nil {
 		t.Errorf("Didn't expect nonevalidator to return an error: %s", err)
@@ -52,7 +53,9 @@ func TestHS256validate(t *testing.T) {
 }
 
 func TestHS256sign(t *testing.T) {
-	HS256V := newHSValidator(sha256.New)
+	HS256V := NewHSValidator(HS256)
+	HS256V.Key = []byte("bogokey")
+
 	b64Signature := "Ayw1D-27S5W4XfiP-nFRm_BxSpN-v_cqlWUiwszjAB8="
 
 	JWT := &JWT{
@@ -66,7 +69,7 @@ func TestHS256sign(t *testing.T) {
 		Signature: []byte(""),
 	}
 
-	err := HS256V.sign(JWT, []byte("bogokey"))
+	err := HS256V.sign(JWT)
 
 	if err != nil {
 		t.Errorf("Didn't expect hs256validator.Sign to return an error: %s", err)
@@ -76,7 +79,8 @@ func TestHS256sign(t *testing.T) {
 		t.Errorf("Invalid signature from hs256validator. Got %#v; Expected %#v", string(JWT.Signature), b64Signature)
 	}
 
-	err = HS256V.sign(JWT, []byte("definitely the wrong key"))
+	HS256V.Key = []byte("definitely the wrong key")
+	err = HS256V.sign(JWT)
 
 	if err != nil {
 		t.Errorf("Didn't expect hs256validator.Sign to return an error: %s", err)

--- a/hs_test.go
+++ b/hs_test.go
@@ -1,0 +1,88 @@
+// Copyright 2015 Benjamin Campbell <benji@benjica.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jwt
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"testing"
+)
+
+func TestHS256validate(t *testing.T) {
+
+	HS256V := newHSValidator(sha256.New)
+	b64Header := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+	b64Payload := "eyJzdWIiOiIxMjM0NTY3ODkwIn0"
+	b64Signature := "Ayw1D-27S5W4XfiP-nFRm_BxSpN-v_cqlWUiwszjAB8"
+
+	JWT := &JWT{
+		Header: &Header{
+			Algorithm:   HS256,
+			ContentType: "JWT",
+		},
+		headerRaw: []byte(b64Header),
+		Payload: &Payload{
+			Subject: "1234567890",
+		},
+		payloadRaw: []byte(b64Payload),
+		Signature:  []byte(b64Signature),
+	}
+
+	valid, err := HS256V.validate(JWT, []byte("bogokey"))
+
+	if err != nil {
+		t.Errorf("Didn't expect nonevalidator to return an error: %s", err)
+	}
+
+	if !valid {
+		t.Errorf("Expected a valid signature")
+	}
+}
+
+func TestHS256sign(t *testing.T) {
+	HS256V := newHSValidator(sha256.New)
+	b64Signature := "Ayw1D-27S5W4XfiP-nFRm_BxSpN-v_cqlWUiwszjAB8="
+
+	JWT := &JWT{
+		Header: &Header{
+			Algorithm:   HS256,
+			ContentType: "JWT",
+		},
+		Payload: &Payload{
+			Subject: "1234567890",
+		},
+		Signature: []byte(""),
+	}
+
+	err := HS256V.sign(JWT, []byte("bogokey"))
+
+	if err != nil {
+		t.Errorf("Didn't expect hs256validator.Sign to return an error: %s", err)
+	}
+
+	if !bytes.Equal(JWT.Signature, []byte(b64Signature)) {
+		t.Errorf("Invalid signature from hs256validator. Got %#v; Expected %#v", string(JWT.Signature), b64Signature)
+	}
+
+	err = HS256V.sign(JWT, []byte("definitely the wrong key"))
+
+	if err != nil {
+		t.Errorf("Didn't expect hs256validator.Sign to return an error: %s", err)
+	}
+
+	if bytes.Equal(JWT.Signature, []byte(b64Signature)) {
+		t.Errorf("An invalid key for hs256validator returned an unexpected value: %#v.", JWT.Signature)
+	}
+}

--- a/jwt.go
+++ b/jwt.go
@@ -134,7 +134,6 @@ func (enc *Encoder) Encode(v interface{}) error {
 	}
 
 	if err := enc.validator.sign(&jwt); err != nil {
-		//TODO: None of the signers return erros
 		return err
 	}
 

--- a/jwt.go
+++ b/jwt.go
@@ -28,11 +28,11 @@ import (
 
 var (
 	// ErrMalformedToken represent errors where the given JWT is improperly formed
-	ErrMalformedToken = errors.New("Malformed Content")
+	ErrMalformedToken = errors.New("malformed Content")
 	// ErrBadSignature represents errors where a signature is invalid
-	ErrBadSignature = errors.New("Invalid Signature")
+	ErrBadSignature = errors.New("invalid Signature")
 	// ErrAlgorithmNotImplemented is thrown if a given JWT is using an algorithm not implemented
-	ErrAlgorithmNotImplemented = errors.New("Requested algorithm is not implemented")
+	ErrAlgorithmNotImplemented = errors.New("requested algorithm is not implemented")
 )
 
 // A Payload in a JWT represents a set of claims for a given token.
@@ -50,15 +50,15 @@ type Payload struct {
 // A Decoder is a centeralized reader and key used to consume and verify a
 // given JWT token.
 type Decoder struct {
-	reader io.Reader
-	key    []byte
+	reader    io.Reader
+	validator Validator
 }
 
 // An Encoder is a centeralized writer and key used to take a given payload and
 // produce a JWT token.
 type Encoder struct {
-	writer io.Writer
-	key    []byte
+	writer    io.Writer
+	validator Validator
 }
 
 // A Header contains data related to the signature of the payload. This information
@@ -84,9 +84,8 @@ type JWT struct {
 }
 
 // NewDecoder creates an underlying Decoder with a given key and input reader
-func NewDecoder(r io.Reader, key []byte) *Decoder {
-	Decoder := &Decoder{reader: r, key: key}
-	return Decoder
+func NewDecoder(r io.Reader, v Validator) *Decoder {
+	return &Decoder{reader: r, validator: v}
 }
 
 // Decode consumes the next available token from the given reader and populates
@@ -105,7 +104,7 @@ func (dec *Decoder) Decode(v interface{}) error {
 		return err
 	}
 
-	if valid, err := jwt.validateSignature(dec.key); !valid || err != nil {
+	if valid, err := dec.validator.validate(jwt); !valid || err != nil {
 
 		if err != nil {
 			return err
@@ -118,29 +117,28 @@ func (dec *Decoder) Decode(v interface{}) error {
 }
 
 // NewEncoder creates an underlying Encoder with a given key and output writer
-func NewEncoder(w io.Writer, key []byte) *Encoder {
-	return &Encoder{writer: w, key: key}
+func NewEncoder(w io.Writer, v Validator) *Encoder {
+	return &Encoder{writer: w, validator: v}
 }
 
 // Encode takes a given payload and algorithm and composes a new signed JWT
 // in the underlying writer. This will return an error in the event that the
 // given payload cannot be encoded to JSON.
-func (enc *Encoder) Encode(v interface{}, alg Algorithm) error {
+func (enc *Encoder) Encode(v interface{}) error {
 
-	JWT := JWT{
+	jwt := JWT{
 		Header: &Header{
-			Algorithm:   alg,
 			ContentType: "JWT",
 		},
 		Payload: v,
 	}
 
-	if err := JWT.sign(enc.key); err != nil {
+	if err := enc.validator.sign(&jwt); err != nil {
 		//TODO: None of the signers return erros
 		return err
 	}
 
-	fmt.Fprintf(enc.writer, "%s", JWT.token())
+	fmt.Fprintf(enc.writer, "%s", jwt.token())
 
 	return nil
 }
@@ -186,33 +184,6 @@ func parseJWT(input string, payload interface{}) (*JWT, error) {
 	jwt.Signature = []byte(fields[2])
 
 	return jwt, nil
-}
-
-// validateSignature uses the header of a given JWT to determine a the signing algorithm
-// and validates it. Can return an errAlgorithmNotImplemented if using a not yet implemented
-// signing method.
-func (jwt *JWT) validateSignature(key []byte) (bool, error) {
-
-	validator, err := getvalidator(jwt.Header.Algorithm)
-
-	if err != nil {
-		return false, err
-	}
-
-	return validator.validate(jwt, key)
-}
-
-func (jwt *JWT) sign(key []byte) error {
-	var validator validator
-	var err error
-
-	if validator, err = getvalidator(jwt.Header.Algorithm); err != nil {
-		return err
-	}
-
-	validator.sign(jwt, key)
-
-	return nil
 }
 
 func (jwt *JWT) token() string {

--- a/jwt.go
+++ b/jwt.go
@@ -223,17 +223,6 @@ func (jwt *JWT) token() string {
 	return fmt.Sprintf("%s.%s.%s", header, payload, signature)
 }
 
-func getvalidator(alg Algorithm) (validator, error) {
-	switch alg {
-	case HS256:
-		return hs256validator{}, nil
-	case None:
-		return nonevalidator{}, nil
-	default:
-		return nil, ErrAlgorithmNotImplemented
-	}
-}
-
 func (jwt *JWT) parsePayload(raw string, v interface{}) error {
 	jwt.payloadRaw = []byte(raw)
 	value, err := parseField(raw)

--- a/rs.go
+++ b/rs.go
@@ -1,0 +1,90 @@
+// Copyright 2015 Benjamin Campbell <benji@benjica.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jwt
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"hash"
+	"io"
+	"strings"
+)
+
+// A RSValidator implments the validator interface and allows the singing and verification
+// of signatures with RSA PCSK1.5 algorithms.
+type RSValidator struct {
+	algorithm  Algorithm
+	hashType   crypto.Hash
+	hashFunc   func() hash.Hash
+	randReader io.Reader
+	PublicKey  *rsa.PublicKey
+	PrivateKey *rsa.PrivateKey
+}
+
+// NewRSValidator constructs a RSValidator
+func NewRSValidator(algorithm Algorithm) RSValidator {
+	// TODO: Implement all sha algorithms
+	return RSValidator{
+		algorithm:  algorithm,
+		hashType:   crypto.SHA256,
+		hashFunc:   sha256.New,
+		randReader: rand.Reader,
+	}
+}
+
+func (v RSValidator) validate(jwt *JWT) (bool, error) {
+
+	if v.PublicKey == nil {
+		return false, ErrBadSignature
+	}
+
+	jwt.Header.Algorithm = v.algorithm
+	jwt.rawEncode()
+
+	signature, err := base64.URLEncoding.DecodeString(string(jwt.Signature))
+
+	if err != nil {
+		return false, err
+	}
+
+	hsh := v.hashFunc()
+	hsh.Write([]byte(string(jwt.headerRaw) + "." + string(jwt.payloadRaw)))
+	hash := hsh.Sum(nil)
+
+	err = rsa.VerifyPKCS1v15(v.PublicKey, v.hashType, hash, signature)
+
+	if err != nil {
+		return false, ErrBadSignature
+	}
+
+	return true, nil
+}
+
+func (v RSValidator) sign(jwt *JWT) (err error) {
+	jwt.Header.Algorithm = v.algorithm
+	jwt.rawEncode()
+
+	hsh := v.hashFunc()
+	hsh.Write([]byte(string(jwt.headerRaw) + "." + string(jwt.payloadRaw)))
+	hash := hsh.Sum(nil)
+
+	signature, _ := rsa.SignPKCS1v15(v.randReader, v.PrivateKey, v.hashType, hash)
+	jwt.Signature = []byte(strings.Trim(base64.URLEncoding.EncodeToString(signature), "="))
+
+	return err
+}

--- a/rs.go
+++ b/rs.go
@@ -19,6 +19,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/base64"
 	"hash"
 	"io"
@@ -37,14 +38,24 @@ type RSValidator struct {
 }
 
 // NewRSValidator constructs a RSValidator
-func NewRSValidator(algorithm Algorithm) RSValidator {
-	// TODO: Implement all sha algorithms
-	return RSValidator{
-		algorithm:  algorithm,
-		hashType:   crypto.SHA256,
-		hashFunc:   sha256.New,
-		randReader: rand.Reader,
+func NewRSValidator(algorithm Algorithm) (v RSValidator, err error) {
+	v = RSValidator{algorithm: algorithm, randReader: rand.Reader}
+
+	switch algorithm {
+	case RS256:
+		v.hashType = crypto.SHA256
+		v.hashFunc = sha256.New
+	case RS384:
+		v.hashType = crypto.SHA384
+		v.hashFunc = sha512.New384
+	case RS512:
+		v.hashType = crypto.SHA512
+		v.hashFunc = sha512.New
+	default:
+		err = ErrAlgorithmNotImplemented
 	}
+
+	return v, err
 }
 
 func (v RSValidator) validate(jwt *JWT) (bool, error) {

--- a/rs_test.go
+++ b/rs_test.go
@@ -62,7 +62,7 @@ YwIDAQAB
 -----END PUBLIC KEY-----`
 
 func TestRSValidate(t *testing.T) {
-	RS256V := NewRSValidator(RS256)
+	RS256V, _ := NewRSValidator(RS256)
 	block, _ := pem.Decode([]byte(publicKey))
 	if block == nil {
 		t.Error("Unable to parse block from pem\n")
@@ -128,10 +128,31 @@ func TestRSValidate(t *testing.T) {
 
 }
 
+func TestNewRSValidator(t *testing.T) {
+	cases := []struct {
+		Algorithm     Algorithm
+		ExpectedError error
+		Reason        string
+	}{
+		{RS256, nil, "expected to get a valid RS256 validator"},
+		{RS384, nil, "expected to get a valid RS384 validator"},
+		{RS512, nil, "expected to get a valid RS512 validator"},
+		{None, ErrAlgorithmNotImplemented, "did not expect to get a valid RS validator"},
+	}
+
+	for _, c := range cases {
+		_, err := NewRSValidator(c.Algorithm)
+
+		if err != c.ExpectedError {
+			t.Errorf("%s: got %s", c.Reason, err)
+		}
+	}
+}
+
 func TestRSSign(t *testing.T) {
 	var err error
 
-	RS256V := NewRSValidator(RS256)
+	RS256V, _ := NewRSValidator(RS256)
 	block, _ := pem.Decode([]byte(privateKey))
 	if block == nil {
 		t.Errorf("Recieved error when parisng test private key: %s\n", err)

--- a/rs_test.go
+++ b/rs_test.go
@@ -165,6 +165,8 @@ func TestRSSign(t *testing.T) {
 		t.FailNow()
 	}
 
+	RS256V.randReader = nullReader{}
+
 	b64Signature := "e-mU_hjtyUkDZfe63d-WN2YlTXJkMdaR04sbORQQGKFtLYSvVVknU8rbhlGq4eWCCFnYgK9_vJ37DpIV-OBLZ1JoWvmdh1oIHJsY9PJLhw4fK6Hq20Vfde-AkCWQT3I4r93Ymc3J-sRUGrDeKLmnbWnPeC6TQS7f8vjLHnCcvOFNK7BmJadhRDfI3Wxh988KP71v9I6lSlN_zWXPbdlFljBQzF0bpyDgidCqr2EqeJpnBBeE_0Bs7J1d34N0jyEs6P5aMsoIlI07bl_zoEJ2aYWuUNR9qbyK1K-OpAGG7X7l4qLmPP1HdQmHO9JkchShLgj8soDgnZBaFAm1Us_nwA"
 	JWT := &JWT{
 		Header: &Header{

--- a/rs_test.go
+++ b/rs_test.go
@@ -1,0 +1,183 @@
+// Copyright 2015 Benjamin Campbell <benji@benjica.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jwt
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+)
+
+const privateKey string = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAzIIdoS0tocpJxSLYfS1RnBVAsSjLjjUtLXahPuo3NmvuEPc6
+mEseT73aKUHiq8Twio6oiwFGWcsy+da5Ta17aTfMzVNxG4DJvocdGEr+YO/EKm+d
+eURjOEcZ3rW+bHPc2HnTkMqpWQ10jIBu91RaYmyWpvnz9oOW6st8MVSNMJKPBowR
+lvMDKMqmsyX13nTvmQN3m/OqE6o8gYhj0mvP+U4sJ0bc/LgAWed54b1AWLlh6NML
+K3wSWP0Ve5oIQnIzR4wwtptonZ9SNtWVKL3EZhX0/DjL/1qd8aXzjFn1ivFUEB7E
+SSaNjFOrk/64TN00uwizXbbtc76Ttd6MnOfTYwIDAQABAoIBAQCaHlCP/4kNDXKM
+sxbtNvLyqn2HRRQqBl8WjPk1fbLAO5Q8iuRIkwuz0oKPZwyYoCEaeioAH6TR1LWE
+3NHm/R8tCxU3g3OQ43ymLhK6FQIhMW/m/xhwpB4V8ldHpDVua9558U2EJ4Z6Cw7T
+N5Lop1Q6KlVaXrIBC+f26ASe9HY2rFLBWtG2IS26f2P6zjdl5MDrumvmHGTIk8Jf
+KvoOnJ5fWK52K57GJEA+ZP1b9Qf5D1HeFhi2P5sp/8ivFl6zKe2h9Lu7pOTqLz6o
+9XcqFY95y+TcmaTuGyyrIyrrcluPF6Zh5OrTVEMv3uso6MK8nWRwYDCMjUjHmBkI
+rTsJRLeJAoGBAPNRJhRHjWUIlIrE3nlsHsbxZC8rkvzSyIh5vH7RWYiuhOgTtkQn
+7dV2d/xoSOIn6YU6LC+k++D7z0BtD/3MKUZyz+b2k5STrGJdDjaZ3S2+hceO9889
+CPLPszqvURk0wEtEPFeEAWKWCzGfgu/lTvu1dS4LQc+FznFyOhmdT3JNAoGBANcr
+GUVBUyJ2n0l3JPLOwTYXucg57ilqUygOAm1j71fFKM5mWkvusigDdPxaPl+Znhoz
+gZR5vi72AUHVxWArxrnRMYF5aNTjdjtTAuOXQ+9HBti7zgSiQ8NDvo6DKMOdcM7G
+xv8AUAQMzd6XKGvGuehcHoXXfnSgaqeGHgqfxFRvAoGAY/tqfFbSoTufXk57ZMWq
+9/DlTATJx54NzRbJAAuikOm1r2+6K9OEhXzC3TM1D8l6ycYXthRDdDXE+iJWueGU
+7F/tUmjsR9dOtLSsTH95RXzOmCwFZGEeNjhm26yC1Kq6gbMuYH/b2djyDJgRQ+ak
+SAZOenchudav+CoJ+dCMftkCgYBvglp6Vbxr4+XxANoZK6VeDzWs2rjepceqvnfr
+kRr89aSMMucg6vdRXVlHXs1sZgRVt9OzytQRKlTEdbDwgj9fFVb+rpjxm2Aupnqc
+0EvYuYqGz+2Y4S8VBwq+eKKrnfBUeRewF81gC/K1JMlB8Z9vGC6JVoCmmGwtnYf8
+IYhx6QKBgBkSg6Gg+fVXgwmHUgrRKSgYEmFVo1oZ4Xq2zdbYbiIL+JM5o2W0wq59
+42tO/Fq3GPKuIzIZPFMuCboqK8wY6n3Tkox2Mkn1QKUV/Aqtd21g3goil8uycXun
+7WFocvEp7a7UHVKH0ArP4K6INgxb7+Xd9kdXvbH8wITFJD1Eu/jP
+-----END RSA PRIVATE KEY-----`
+
+const publicKey string = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzIIdoS0tocpJxSLYfS1R
+nBVAsSjLjjUtLXahPuo3NmvuEPc6mEseT73aKUHiq8Twio6oiwFGWcsy+da5Ta17
+aTfMzVNxG4DJvocdGEr+YO/EKm+deURjOEcZ3rW+bHPc2HnTkMqpWQ10jIBu91Ra
+YmyWpvnz9oOW6st8MVSNMJKPBowRlvMDKMqmsyX13nTvmQN3m/OqE6o8gYhj0mvP
++U4sJ0bc/LgAWed54b1AWLlh6NMLK3wSWP0Ve5oIQnIzR4wwtptonZ9SNtWVKL3E
+ZhX0/DjL/1qd8aXzjFn1ivFUEB7ESSaNjFOrk/64TN00uwizXbbtc76Ttd6MnOfT
+YwIDAQAB
+-----END PUBLIC KEY-----`
+
+func TestRSValidate(t *testing.T) {
+	RS256V := NewRSValidator(RS256)
+	block, _ := pem.Decode([]byte(publicKey))
+	if block == nil {
+		t.Error("Unable to parse block from pem\n")
+		t.FailNow()
+	}
+	pubKey, err := x509.ParsePKIXPublicKey(block.Bytes)
+
+	if err != nil {
+		t.Errorf("Recieved error when parisng test private key: %s\n", err)
+		t.FailNow()
+	}
+
+	b64Header := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9"
+	b64Payload := "eyJzdWIiOiIxMjM0NTY3ODkwIn0"
+	b64Signature := "e-mU_hjtyUkDZfe63d-WN2YlTXJkMdaR04sbORQQGKFtLYSvVVknU8rbhlGq4eWCCFnYgK9_vJ37DpIV-OBLZ1JoWvmdh1oIHJsY9PJLhw4fK6Hq20Vfde-AkCWQT3I4r93Ymc3J-sRUGrDeKLmnbWnPeC6TQS7f8vjLHnCcvOFNK7BmJadhRDfI3Wxh988KP71v9I6lSlN_zWXPbdlFljBQzF0bpyDgidCqr2EqeJpnBBeE_0Bs7J1d34N0jyEs6P5aMsoIlI07bl_zoEJ2aYWuUNR9qbyK1K-OpAGG7X7l4qLmPP1HdQmHO9JkchShLgj8soDgnZBaFAm1Us_nwA=="
+
+	JWT := &JWT{
+		Header: &Header{
+			Algorithm:   RS256,
+			ContentType: "JWT",
+		},
+		headerRaw: []byte(b64Header),
+		Payload: &Payload{
+			Subject: "1234567890",
+		},
+		payloadRaw: []byte(b64Payload),
+	}
+
+	valid, err := RS256V.validate(JWT)
+
+	if valid || err == nil {
+		t.Error("Expected a nil public key pointer to return invalid")
+	}
+
+	RS256V.PublicKey = pubKey.(*rsa.PublicKey)
+	JWT.Signature = []byte("invalid base64 string")
+	valid, err = RS256V.validate(JWT)
+
+	if valid || err == nil {
+		t.Error("Expected validate to return invalid signature and error when using bad base64 signature")
+	}
+
+	JWT.Signature = []byte(b64Signature)
+	valid, err = RS256V.validate(JWT)
+
+	if !valid || err != nil {
+		if err != nil {
+			t.Errorf("Didn't expect rsvalidator to return an error: %s", err)
+		}
+		t.Errorf("Expectd to find valid siganture")
+	}
+
+	JWT.Signature = []byte("YmFkIHNpZ25hdHVyZQo=")
+
+	valid, err = RS256V.validate(JWT)
+
+	if valid || err == nil {
+		if err == nil {
+			t.Errorf("Didn't expect rsvalidator to return an error: %s", err)
+		}
+		t.Errorf("Expectd to find valid siganture")
+	}
+
+}
+
+func TestRSSign(t *testing.T) {
+	var err error
+
+	RS256V := NewRSValidator(RS256)
+	block, _ := pem.Decode([]byte(privateKey))
+	if block == nil {
+		t.Errorf("Recieved error when parisng test private key: %s\n", err)
+		t.FailNow()
+	}
+
+	RS256V.PrivateKey, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		t.Errorf("Recieved error when parisng test private key: %s\n", err)
+		t.FailNow()
+	}
+
+	b64Signature := "e-mU_hjtyUkDZfe63d-WN2YlTXJkMdaR04sbORQQGKFtLYSvVVknU8rbhlGq4eWCCFnYgK9_vJ37DpIV-OBLZ1JoWvmdh1oIHJsY9PJLhw4fK6Hq20Vfde-AkCWQT3I4r93Ymc3J-sRUGrDeKLmnbWnPeC6TQS7f8vjLHnCcvOFNK7BmJadhRDfI3Wxh988KP71v9I6lSlN_zWXPbdlFljBQzF0bpyDgidCqr2EqeJpnBBeE_0Bs7J1d34N0jyEs6P5aMsoIlI07bl_zoEJ2aYWuUNR9qbyK1K-OpAGG7X7l4qLmPP1HdQmHO9JkchShLgj8soDgnZBaFAm1Us_nwA"
+	JWT := &JWT{
+		Header: &Header{
+			Algorithm:   RS256,
+			ContentType: "JWT",
+		},
+		Payload: &Payload{
+			Subject: "1234567890",
+		},
+	}
+
+	err = RS256V.sign(JWT)
+
+	if err != nil {
+		t.Errorf("Didn't expect rs256validator.Sign to return an error: %s", err)
+	}
+
+	if !bytes.Equal(JWT.Signature, []byte(b64Signature)) {
+		t.Errorf("Invalid signature from rs256validator. Got %#v; Expected %#v", string(JWT.Signature), b64Signature)
+	}
+
+	badKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Error("Error generating new key")
+	}
+
+	RS256V.PrivateKey = badKey
+	err = RS256V.sign(JWT)
+
+	if err != nil {
+		t.Errorf("Didn't expect hs256validator.Sign to return an error: %s", err)
+	}
+
+	if bytes.Equal(JWT.Signature, []byte(b64Signature)) {
+		t.Errorf("An invalid key for hs256validator returned an unexpected value: %#v.", JWT.Signature)
+	}
+}


### PR DESCRIPTION
## Problem

The library only allows for a limited number of signing algorithms.
## Solution

Implement the remaining algorithms established as status quo on [jwt.io](http://jwt.io)
# TODO
- [x] HMAC Signing algorithms (_HS Algorithms_)
- [x] Public key signing algorithms (_RS Algorithms_)
- [x] Elliptic Curve signing algorithms (_ES Algorithms_)
